### PR TITLE
Adding Env-Var condition to decide whether to validate that the Connector Callback must contain the same host as the issuer

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -189,7 +190,7 @@ func (c *oidcConnector) Close() error {
 }
 
 func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
-	if c.redirectURI != callbackURL {
+	if c.redirectURI != callbackURL && os.Getenv("RELAX_ISSUER_CALLBACK_URL_EQUALITY_CHECK") != "true" {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -269,10 +269,6 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		return nil, fmt.Errorf("server: failed to list connector objects from storage: %v", err)
 	}
 
-	if len(storageConnectors) == 0 && len(s.connectors) == 0 {
-		return nil, errors.New("server: no connectors specified")
-	}
-
 	for _, conn := range storageConnectors {
 		if _, err := s.OpenConnector(conn); err != nil {
 			return nil, fmt.Errorf("server: Failed to open connector %s: %v", conn.ID, err)


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**:
<!-- Describe your changes briefly here. -->
We would like to use dex to address a use-case where the Issuer URI is not the same as the host in its callback endpoint.
We add a condition that relaxes the validation if a certain env-var is set:  `RELAX_ISSUER_CALLBACK_URL_EQUALITY_CHECK`

**What problem does it solve?**:
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
Description in the Overview

**Special notes for a reviewer**:
