### PR TITLE
pass login_hint to OIDC connector's /auth endpoint in auth_code flow

### DIFF
--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -37,7 +37,7 @@ type callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)

--- a/connector/authproxy/authproxy.go
+++ b/connector/authproxy/authproxy.go
@@ -37,7 +37,7 @@ type callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (m *callback) LoginURL(s connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)

--- a/connector/bitbucketcloud/bitbucketcloud.go
+++ b/connector/bitbucketcloud/bitbucketcloud.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -111,7 +112,7 @@ func (b *bitbucketConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if b.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, b.redirectURI)
 	}

--- a/connector/bitbucketcloud/bitbucketcloud.go
+++ b/connector/bitbucketcloud/bitbucketcloud.go
@@ -111,7 +111,7 @@ func (b *bitbucketConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (b *bitbucketConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if b.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, b.redirectURI)
 	}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -63,7 +63,7 @@ type CallbackConnector interface {
 	// requested if one has already been issues. There's no good general answer
 	// for these kind of restrictions, and may require this package to become more
 	// aware of the global set of user/connector interactions.
-	LoginURL(s Scopes, callbackURL, state string) (string, error)
+	LoginURL(s Scopes, callbackURL, state string, forwardedParams map[string]string) (string, error)
 
 	// Handle the callback to the server and return an identity.
 	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -4,6 +4,7 @@ package connector
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // Connector is a mechanism for federating login to a remote identity service.
@@ -63,7 +64,7 @@ type CallbackConnector interface {
 	// requested if one has already been issues. There's no good general answer
 	// for these kind of restrictions, and may require this package to become more
 	// aware of the global set of user/connector interactions.
-	LoginURL(s Scopes, callbackURL, state string, forwardedParams map[string]string) (string, error)
+	LoginURL(s Scopes, callbackURL, state string, forwardedParams url.Values) (string, error)
 
 	// Handle the callback to the server and return an identity.
 	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)

--- a/connector/gitea/gitea.go
+++ b/connector/gitea/gitea.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -82,7 +83,7 @@ func (c *giteaConnector) oauth2Config(_ connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}

--- a/connector/gitea/gitea.go
+++ b/connector/gitea/gitea.go
@@ -82,7 +82,7 @@ func (c *giteaConnector) oauth2Config(_ connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *giteaConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -187,7 +187,7 @@ func (c *githubConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -187,7 +188,7 @@ func (c *githubConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *githubConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"golang.org/x/oauth2"
@@ -98,7 +99,7 @@ func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}

--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -98,7 +98,7 @@ func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
 	}
 }
 
-func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *gitlabConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", c.redirectURI, callbackURL)
 	}

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -120,7 +121,7 @@ func (c *googleConnector) Close() error {
 	return nil
 }
 
-func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/google/google.go
+++ b/connector/google/google.go
@@ -120,7 +120,7 @@ func (c *googleConnector) Close() error {
 	return nil
 }
 
-func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (c *googleConnector) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/linkedin/linkedin.go
+++ b/connector/linkedin/linkedin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -62,7 +63,7 @@ var (
 )
 
 // LoginURL returns an access token request URL
-func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.oauth2Config.RedirectURL != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q",
 			callbackURL, c.oauth2Config.RedirectURL)

--- a/connector/linkedin/linkedin.go
+++ b/connector/linkedin/linkedin.go
@@ -62,7 +62,7 @@ var (
 )
 
 // LoginURL returns an access token request URL
-func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *linkedInConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.oauth2Config.RedirectURL != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q",
 			callbackURL, c.oauth2Config.RedirectURL)

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -151,7 +151,7 @@ func (c *microsoftConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -151,7 +152,7 @@ func (c *microsoftConnector) oauth2Config(scopes connector.Scopes) *oauth2.Confi
 	}
 }
 
-func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *microsoftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -43,7 +43,7 @@ type Callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -43,7 +43,7 @@ type Callback struct {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+func (m *Callback) LoginURL(s connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	u, err := url.Parse(callbackURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -201,6 +201,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string, 
 	if c.redirectURI != callbackURL && !c.insecureSkipIssuerCallbackDomainCheck {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
+
 	var opts []oauth2.AuthCodeOption
 	if len(c.hostedDomains) > 0 {
 		preferredDomain := c.hostedDomains[0]

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -197,7 +197,7 @@ func (c *oidcConnector) Close() error {
 	return nil
 }
 
-func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string, forwardParams map[string]string) (string, error) {
+func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string, forwardParams url.Values) (string, error) {
 	if c.redirectURI != callbackURL && !c.insecureSkipIssuerCallbackDomainCheck {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
@@ -214,7 +214,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string, 
 		opts = append(opts, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", c.promptType))
 	}
 
-	for p, v := range forwardParams {
+	for p := range forwardParams {
 		paramApproved := false
 		for _, approvedParam := range c.forwardedLoginParams {
 			if p == approvedParam {
@@ -223,7 +223,7 @@ func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string, 
 			}
 		}
 		if paramApproved {
-			opts = append(opts, oauth2.SetAuthURLParam(p, v))
+			opts = append(opts, oauth2.SetAuthURLParam(p, forwardParams.Get(p)))
 		} else {
 			c.logger.Infof("oidc: auth query parameter %s, is unapproved and was not forwarded to the connector idp", p)
 		}

--- a/connector/openshift/openshift.go
+++ b/connector/openshift/openshift.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -117,7 +118,7 @@ func (c *openshiftConnector) Close() error {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
+func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ url.Values) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/connector/openshift/openshift.go
+++ b/connector/openshift/openshift.go
@@ -117,7 +117,7 @@ func (c *openshiftConnector) Close() error {
 }
 
 // LoginURL returns the URL to redirect the user to login with.
-func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *openshiftConnector) LoginURL(scopes connector.Scopes, callbackURL, state string, _ map[string]string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -184,7 +184,7 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
-	authReq, err := s.parseAuthorizationRequest(r)
+	authReq, forwardParams, err := s.parseAuthorizationRequest(r)
 	if err != nil {
 		s.logger.Errorf("Failed to parse authorization request: %v", err)
 		status := http.StatusInternalServerError
@@ -247,10 +247,6 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		switch conn := conn.Connector.(type) {
 		case connector.CallbackConnector:
-			forwardParams := make(map[string]string)
-			if authReq.LoginHint != "" {
-				forwardParams["login_hint"] = authReq.LoginHint
-			}
 			// Use the auth request ID as the "state" token.
 			//
 			// TODO(ericchiang): Is this appropriate or should we also be using a nonce?

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -247,10 +247,14 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		switch conn := conn.Connector.(type) {
 		case connector.CallbackConnector:
+			forwardParams := make(map[string]string)
+			if authReq.LoginHint != "" {
+				forwardParams["login_hint"] = authReq.LoginHint
+			}
 			// Use the auth request ID as the "state" token.
 			//
 			// TODO(ericchiang): Is this appropriate or should we also be using a nonce?
-			callbackURL, err := conn.LoginURL(scopes, s.absURL("/callback"), authReq.ID)
+			callbackURL, err := conn.LoginURL(scopes, s.absURL("/callback"), authReq.ID, forwardParams)
 			if err != nil {
 				s.logger.Errorf("Connector %q returned error when creating callback: %v", connID, err)
 				s.renderError(r, w, http.StatusInternalServerError, "Login error.")

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -570,6 +570,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (*storage.AuthReques
 		RedirectURI:         redirectURI,
 		ResponseTypes:       responseTypes,
 		ConnectorID:         connectorID,
+		LoginHint:           q.Get("login_hint"),
 		PKCE: storage.PKCE{
 			CodeChallenge:       codeChallenge,
 			CodeChallengeMethod: codeChallengeMethod,

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -320,7 +320,7 @@ func TestParseAuthorizationRequest(t *testing.T) {
 				req = httptest.NewRequest("GET", httpServer.URL+"/auth?"+params.Encode(), nil)
 			}
 
-			_, err := server.parseAuthorizationRequest(req)
+			_, _, err := server.parseAuthorizationRequest(req)
 			if tc.wantErr {
 				require.Error(t, err)
 				if tc.exactError != nil {

--- a/storage/ent/db/authrequest.go
+++ b/storage/ent/db/authrequest.go
@@ -55,6 +55,8 @@ type AuthRequest struct {
 	CodeChallenge string `json:"code_challenge,omitempty"`
 	// CodeChallengeMethod holds the value of the "code_challenge_method" field.
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
+	// LoginHint holds the value of the "login_hint" field.
+	LoginHint string `json:"login_hint,omitempty"`
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -66,7 +68,7 @@ func (*AuthRequest) scanValues(columns []string) ([]interface{}, error) {
 			values[i] = new([]byte)
 		case authrequest.FieldForceApprovalPrompt, authrequest.FieldLoggedIn, authrequest.FieldClaimsEmailVerified:
 			values[i] = new(sql.NullBool)
-		case authrequest.FieldID, authrequest.FieldClientID, authrequest.FieldRedirectURI, authrequest.FieldNonce, authrequest.FieldState, authrequest.FieldClaimsUserID, authrequest.FieldClaimsUsername, authrequest.FieldClaimsEmail, authrequest.FieldClaimsPreferredUsername, authrequest.FieldConnectorID, authrequest.FieldCodeChallenge, authrequest.FieldCodeChallengeMethod:
+		case authrequest.FieldID, authrequest.FieldClientID, authrequest.FieldRedirectURI, authrequest.FieldNonce, authrequest.FieldState, authrequest.FieldClaimsUserID, authrequest.FieldClaimsUsername, authrequest.FieldClaimsEmail, authrequest.FieldClaimsPreferredUsername, authrequest.FieldConnectorID, authrequest.FieldCodeChallenge, authrequest.FieldCodeChallengeMethod, authrequest.FieldLoginHint:
 			values[i] = new(sql.NullString)
 		case authrequest.FieldExpiry:
 			values[i] = new(sql.NullTime)
@@ -214,6 +216,12 @@ func (ar *AuthRequest) assignValues(columns []string, values []interface{}) erro
 			} else if value.Valid {
 				ar.CodeChallengeMethod = value.String
 			}
+		case authrequest.FieldLoginHint:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field login_hint", values[i])
+			} else if value.Valid {
+				ar.LoginHint = value.String
+			}
 		}
 	}
 	return nil
@@ -282,6 +290,8 @@ func (ar *AuthRequest) String() string {
 	builder.WriteString(ar.CodeChallenge)
 	builder.WriteString(", code_challenge_method=")
 	builder.WriteString(ar.CodeChallengeMethod)
+	builder.WriteString(", login_hint=")
+	builder.WriteString(ar.LoginHint)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/storage/ent/db/authrequest/authrequest.go
+++ b/storage/ent/db/authrequest/authrequest.go
@@ -45,6 +45,8 @@ const (
 	FieldCodeChallenge = "code_challenge"
 	// FieldCodeChallengeMethod holds the string denoting the code_challenge_method field in the database.
 	FieldCodeChallengeMethod = "code_challenge_method"
+	// FieldLoginHint holds the string denoting the login_hint field in the database.
+	FieldLoginHint = "login_hint"
 	// Table holds the table name of the authrequest in the database.
 	Table = "auth_requests"
 )
@@ -71,6 +73,7 @@ var Columns = []string{
 	FieldExpiry,
 	FieldCodeChallenge,
 	FieldCodeChallengeMethod,
+	FieldLoginHint,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -90,6 +93,8 @@ var (
 	DefaultCodeChallenge string
 	// DefaultCodeChallengeMethod holds the default value on creation for the "code_challenge_method" field.
 	DefaultCodeChallengeMethod string
+	// DefaultLoginHint holds the default value on creation for the "login_hint" field.
+	DefaultLoginHint string
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )

--- a/storage/ent/db/authrequest/where.go
+++ b/storage/ent/db/authrequest/where.go
@@ -204,6 +204,13 @@ func CodeChallengeMethod(v string) predicate.AuthRequest {
 	})
 }
 
+// LoginHint applies equality check predicate on the "login_hint" field. It's identical to LoginHintEQ.
+func LoginHint(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldLoginHint), v))
+	})
+}
+
 // ClientIDEQ applies the EQ predicate on the "client_id" field.
 func ClientIDEQ(v string) predicate.AuthRequest {
 	return predicate.AuthRequest(func(s *sql.Selector) {
@@ -1672,6 +1679,117 @@ func CodeChallengeMethodEqualFold(v string) predicate.AuthRequest {
 func CodeChallengeMethodContainsFold(v string) predicate.AuthRequest {
 	return predicate.AuthRequest(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldCodeChallengeMethod), v))
+	})
+}
+
+// LoginHintEQ applies the EQ predicate on the "login_hint" field.
+func LoginHintEQ(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintNEQ applies the NEQ predicate on the "login_hint" field.
+func LoginHintNEQ(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintIn applies the In predicate on the "login_hint" field.
+func LoginHintIn(vs ...string) predicate.AuthRequest {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldLoginHint), v...))
+	})
+}
+
+// LoginHintNotIn applies the NotIn predicate on the "login_hint" field.
+func LoginHintNotIn(vs ...string) predicate.AuthRequest {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldLoginHint), v...))
+	})
+}
+
+// LoginHintGT applies the GT predicate on the "login_hint" field.
+func LoginHintGT(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintGTE applies the GTE predicate on the "login_hint" field.
+func LoginHintGTE(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintLT applies the LT predicate on the "login_hint" field.
+func LoginHintLT(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintLTE applies the LTE predicate on the "login_hint" field.
+func LoginHintLTE(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintContains applies the Contains predicate on the "login_hint" field.
+func LoginHintContains(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintHasPrefix applies the HasPrefix predicate on the "login_hint" field.
+func LoginHintHasPrefix(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintHasSuffix applies the HasSuffix predicate on the "login_hint" field.
+func LoginHintHasSuffix(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintEqualFold applies the EqualFold predicate on the "login_hint" field.
+func LoginHintEqualFold(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldLoginHint), v))
+	})
+}
+
+// LoginHintContainsFold applies the ContainsFold predicate on the "login_hint" field.
+func LoginHintContainsFold(v string) predicate.AuthRequest {
+	return predicate.AuthRequest(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldLoginHint), v))
 	})
 }
 

--- a/storage/ent/db/authrequest_create.go
+++ b/storage/ent/db/authrequest_create.go
@@ -158,6 +158,20 @@ func (arc *AuthRequestCreate) SetNillableCodeChallengeMethod(s *string) *AuthReq
 	return arc
 }
 
+// SetLoginHint sets the "login_hint" field.
+func (arc *AuthRequestCreate) SetLoginHint(s string) *AuthRequestCreate {
+	arc.mutation.SetLoginHint(s)
+	return arc
+}
+
+// SetNillableLoginHint sets the "login_hint" field if the given value is not nil.
+func (arc *AuthRequestCreate) SetNillableLoginHint(s *string) *AuthRequestCreate {
+	if s != nil {
+		arc.SetLoginHint(*s)
+	}
+	return arc
+}
+
 // SetID sets the "id" field.
 func (arc *AuthRequestCreate) SetID(s string) *AuthRequestCreate {
 	arc.mutation.SetID(s)
@@ -228,6 +242,10 @@ func (arc *AuthRequestCreate) defaults() {
 		v := authrequest.DefaultCodeChallengeMethod
 		arc.mutation.SetCodeChallengeMethod(v)
 	}
+	if _, ok := arc.mutation.LoginHint(); !ok {
+		v := authrequest.DefaultLoginHint
+		arc.mutation.SetLoginHint(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -276,6 +294,9 @@ func (arc *AuthRequestCreate) check() error {
 	}
 	if _, ok := arc.mutation.CodeChallengeMethod(); !ok {
 		return &ValidationError{Name: "code_challenge_method", err: errors.New("db: missing required field \"code_challenge_method\"")}
+	}
+	if _, ok := arc.mutation.LoginHint(); !ok {
+		return &ValidationError{Name: "login_hint", err: errors.New("db: missing required field \"login_hint\"")}
 	}
 	if v, ok := arc.mutation.ID(); ok {
 		if err := authrequest.IDValidator(v); err != nil {
@@ -462,6 +483,14 @@ func (arc *AuthRequestCreate) createSpec() (*AuthRequest, *sqlgraph.CreateSpec) 
 			Column: authrequest.FieldCodeChallengeMethod,
 		})
 		_node.CodeChallengeMethod = value
+	}
+	if value, ok := arc.mutation.LoginHint(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: authrequest.FieldLoginHint,
+		})
+		_node.LoginHint = value
 	}
 	return _node, _spec
 }

--- a/storage/ent/db/authrequest_update.go
+++ b/storage/ent/db/authrequest_update.go
@@ -189,6 +189,20 @@ func (aru *AuthRequestUpdate) SetNillableCodeChallengeMethod(s *string) *AuthReq
 	return aru
 }
 
+// SetLoginHint sets the "login_hint" field.
+func (aru *AuthRequestUpdate) SetLoginHint(s string) *AuthRequestUpdate {
+	aru.mutation.SetLoginHint(s)
+	return aru
+}
+
+// SetNillableLoginHint sets the "login_hint" field if the given value is not nil.
+func (aru *AuthRequestUpdate) SetNillableLoginHint(s *string) *AuthRequestUpdate {
+	if s != nil {
+		aru.SetLoginHint(*s)
+	}
+	return aru
+}
+
 // Mutation returns the AuthRequestMutation object of the builder.
 func (aru *AuthRequestUpdate) Mutation() *AuthRequestMutation {
 	return aru.mutation
@@ -420,6 +434,13 @@ func (aru *AuthRequestUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: authrequest.FieldCodeChallengeMethod,
 		})
 	}
+	if value, ok := aru.mutation.LoginHint(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: authrequest.FieldLoginHint,
+		})
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, aru.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{authrequest.Label}
@@ -597,6 +618,20 @@ func (aruo *AuthRequestUpdateOne) SetCodeChallengeMethod(s string) *AuthRequestU
 func (aruo *AuthRequestUpdateOne) SetNillableCodeChallengeMethod(s *string) *AuthRequestUpdateOne {
 	if s != nil {
 		aruo.SetCodeChallengeMethod(*s)
+	}
+	return aruo
+}
+
+// SetLoginHint sets the "login_hint" field.
+func (aruo *AuthRequestUpdateOne) SetLoginHint(s string) *AuthRequestUpdateOne {
+	aruo.mutation.SetLoginHint(s)
+	return aruo
+}
+
+// SetNillableLoginHint sets the "login_hint" field if the given value is not nil.
+func (aruo *AuthRequestUpdateOne) SetNillableLoginHint(s *string) *AuthRequestUpdateOne {
+	if s != nil {
+		aruo.SetLoginHint(*s)
 	}
 	return aruo
 }
@@ -854,6 +889,13 @@ func (aruo *AuthRequestUpdateOne) sqlSave(ctx context.Context) (_node *AuthReque
 			Type:   field.TypeString,
 			Value:  value,
 			Column: authrequest.FieldCodeChallengeMethod,
+		})
+	}
+	if value, ok := aruo.mutation.LoginHint(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: authrequest.FieldLoginHint,
 		})
 	}
 	_node = &AuthRequest{config: aruo.config}

--- a/storage/ent/db/migrate/schema.go
+++ b/storage/ent/db/migrate/schema.go
@@ -56,6 +56,7 @@ var (
 		{Name: "expiry", Type: field.TypeTime},
 		{Name: "code_challenge", Type: field.TypeString, Size: 2147483647, Default: "", SchemaType: map[string]string{"sqlite3": "text"}},
 		{Name: "code_challenge_method", Type: field.TypeString, Size: 2147483647, Default: "", SchemaType: map[string]string{"sqlite3": "text"}},
+		{Name: "login_hint", Type: field.TypeString, Size: 2147483647, Default: "", SchemaType: map[string]string{"sqlite3": "text"}},
 	}
 	// AuthRequestsTable holds the schema information for the "auth_requests" table.
 	AuthRequestsTable = &schema.Table{

--- a/storage/ent/db/mutation.go
+++ b/storage/ent/db/mutation.go
@@ -1180,6 +1180,7 @@ type AuthRequestMutation struct {
 	expiry                    *time.Time
 	code_challenge            *string
 	code_challenge_method     *string
+	login_hint                *string
 	clearedFields             map[string]struct{}
 	done                      bool
 	oldValue                  func(context.Context) (*AuthRequest, error)
@@ -2007,6 +2008,42 @@ func (m *AuthRequestMutation) ResetCodeChallengeMethod() {
 	m.code_challenge_method = nil
 }
 
+// SetLoginHint sets the "login_hint" field.
+func (m *AuthRequestMutation) SetLoginHint(s string) {
+	m.login_hint = &s
+}
+
+// LoginHint returns the value of the "login_hint" field in the mutation.
+func (m *AuthRequestMutation) LoginHint() (r string, exists bool) {
+	v := m.login_hint
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLoginHint returns the old "login_hint" field's value of the AuthRequest entity.
+// If the AuthRequest object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AuthRequestMutation) OldLoginHint(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldLoginHint is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldLoginHint requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLoginHint: %w", err)
+	}
+	return oldValue.LoginHint, nil
+}
+
+// ResetLoginHint resets all changes to the "login_hint" field.
+func (m *AuthRequestMutation) ResetLoginHint() {
+	m.login_hint = nil
+}
+
 // Op returns the operation name.
 func (m *AuthRequestMutation) Op() Op {
 	return m.op
@@ -2021,7 +2058,7 @@ func (m *AuthRequestMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AuthRequestMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.client_id != nil {
 		fields = append(fields, authrequest.FieldClientID)
 	}
@@ -2079,6 +2116,9 @@ func (m *AuthRequestMutation) Fields() []string {
 	if m.code_challenge_method != nil {
 		fields = append(fields, authrequest.FieldCodeChallengeMethod)
 	}
+	if m.login_hint != nil {
+		fields = append(fields, authrequest.FieldLoginHint)
+	}
 	return fields
 }
 
@@ -2125,6 +2165,8 @@ func (m *AuthRequestMutation) Field(name string) (ent.Value, bool) {
 		return m.CodeChallenge()
 	case authrequest.FieldCodeChallengeMethod:
 		return m.CodeChallengeMethod()
+	case authrequest.FieldLoginHint:
+		return m.LoginHint()
 	}
 	return nil, false
 }
@@ -2172,6 +2214,8 @@ func (m *AuthRequestMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldCodeChallenge(ctx)
 	case authrequest.FieldCodeChallengeMethod:
 		return m.OldCodeChallengeMethod(ctx)
+	case authrequest.FieldLoginHint:
+		return m.OldLoginHint(ctx)
 	}
 	return nil, fmt.Errorf("unknown AuthRequest field %s", name)
 }
@@ -2314,6 +2358,13 @@ func (m *AuthRequestMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetCodeChallengeMethod(v)
 		return nil
+	case authrequest.FieldLoginHint:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLoginHint(v)
+		return nil
 	}
 	return fmt.Errorf("unknown AuthRequest field %s", name)
 }
@@ -2446,6 +2497,9 @@ func (m *AuthRequestMutation) ResetField(name string) error {
 		return nil
 	case authrequest.FieldCodeChallengeMethod:
 		m.ResetCodeChallengeMethod()
+		return nil
+	case authrequest.FieldLoginHint:
+		m.ResetLoginHint()
 		return nil
 	}
 	return fmt.Errorf("unknown AuthRequest field %s", name)

--- a/storage/ent/db/runtime.go
+++ b/storage/ent/db/runtime.go
@@ -82,6 +82,10 @@ func init() {
 	authrequestDescCodeChallengeMethod := authrequestFields[19].Descriptor()
 	// authrequest.DefaultCodeChallengeMethod holds the default value on creation for the code_challenge_method field.
 	authrequest.DefaultCodeChallengeMethod = authrequestDescCodeChallengeMethod.Default.(string)
+	// authrequestDescLoginHint is the schema descriptor for login_hint field.
+	authrequestDescLoginHint := authrequestFields[20].Descriptor()
+	// authrequest.DefaultLoginHint holds the default value on creation for the login_hint field.
+	authrequest.DefaultLoginHint = authrequestDescLoginHint.Default.(string)
 	// authrequestDescID is the schema descriptor for id field.
 	authrequestDescID := authrequestFields[0].Descriptor()
 	// authrequest.IDValidator is a validator for the "id" field. It is called by the builders before save.

--- a/storage/ent/schema/authrequest.go
+++ b/storage/ent/schema/authrequest.go
@@ -85,6 +85,9 @@ func (AuthRequest) Fields() []ent.Field {
 		field.Text("code_challenge_method").
 			SchemaType(textSchema).
 			Default(""),
+		field.Text("login_hint").
+			SchemaType(textSchema).
+			Default(""),
 	}
 }
 

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -131,10 +131,11 @@ func (c *conn) CreateAuthRequest(a storage.AuthRequest) error {
 			claims_email, claims_email_verified, claims_groups,
 			connector_id, connector_data,
 			expiry,
-			code_challenge, code_challenge_method
+			code_challenge, code_challenge_method, 
+			login_hint
 		)
 		values (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
 		);
 	`,
 		a.ID, a.ClientID, encoder(a.ResponseTypes), encoder(a.Scopes), a.RedirectURI, a.Nonce, a.State,
@@ -144,6 +145,7 @@ func (c *conn) CreateAuthRequest(a storage.AuthRequest) error {
 		a.ConnectorID, a.ConnectorData,
 		a.Expiry,
 		a.PKCE.CodeChallenge, a.PKCE.CodeChallengeMethod,
+		a.LoginHint,
 	)
 	if err != nil {
 		if c.alreadyExistsCheck(err) {
@@ -175,8 +177,9 @@ func (c *conn) UpdateAuthRequest(id string, updater func(a storage.AuthRequest) 
 				claims_groups = $14,
 				connector_id = $15, connector_data = $16,
 				expiry = $17,
-				code_challenge = $18, code_challenge_method = $19
-			where id = $20;
+				code_challenge = $18, code_challenge_method = $19,
+				login_hint = $20
+			where id = $21;
 		`,
 			a.ClientID, encoder(a.ResponseTypes), encoder(a.Scopes), a.RedirectURI, a.Nonce, a.State,
 			a.ForceApprovalPrompt, a.LoggedIn,
@@ -186,6 +189,7 @@ func (c *conn) UpdateAuthRequest(id string, updater func(a storage.AuthRequest) 
 			a.ConnectorID, a.ConnectorData,
 			a.Expiry,
 			a.PKCE.CodeChallenge, a.PKCE.CodeChallengeMethod,
+			a.LoginHint,
 			r.ID,
 		)
 		if err != nil {
@@ -207,7 +211,7 @@ func getAuthRequest(q querier, id string) (a storage.AuthRequest, err error) {
 			claims_user_id, claims_username, claims_preferred_username,
 			claims_email, claims_email_verified, claims_groups,
 			connector_id, connector_data, expiry,
-			code_challenge, code_challenge_method
+			code_challenge, code_challenge_method, login_hint
 		from auth_request where id = $1;
 	`, id).Scan(
 		&a.ID, &a.ClientID, decoder(&a.ResponseTypes), decoder(&a.Scopes), &a.RedirectURI, &a.Nonce, &a.State,
@@ -216,7 +220,7 @@ func getAuthRequest(q querier, id string) (a storage.AuthRequest, err error) {
 		&a.Claims.Email, &a.Claims.EmailVerified,
 		decoder(&a.Claims.Groups),
 		&a.ConnectorID, &a.ConnectorData, &a.Expiry,
-		&a.PKCE.CodeChallenge, &a.PKCE.CodeChallengeMethod,
+		&a.PKCE.CodeChallenge, &a.PKCE.CodeChallengeMethod, &a.LoginHint,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -281,4 +281,11 @@ var migrations = []migration{
 				add column obsolete_token text default '';`,
 		},
 	},
+	{
+		stmts: []string{
+			`
+			alter table auth_request
+				add column login_hint text not null default '';`,
+		},
+	},
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -199,6 +199,7 @@ type AuthRequest struct {
 	RedirectURI   string
 	Nonce         string
 	State         string
+	LoginHint     string
 
 	// The client has indicated that the end user must be shown an approval prompt
 	// on all requests. The server cannot cache their initial action for subsequent


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
To have dex pass the 'login_hint' query param to the OIDC connector, a few changes are made:
- a map of additional forwarded query parameters is passed as an  argument to the LoginURL connector interface. Each connector can choose whether to use these values.
- the OIDC connector decides on which forwarded query parameters to use by consulting a new field in the connector config called `forwardedLoginParams`
-  a login_hint column is added to the auth_request table to fully capture the request details


#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
